### PR TITLE
Fixed race issue with cache manager mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,21 @@ module.exports = {
   // Example for mongo store
   {
     name: 'mongo-store',
-    type: 'mongo',
-    host: 'loclahost',
-    port: '27017',
-    username: 'username',
-    password: 'password',
-    database: 'mymondodb',
-    collection: 'cacheManager',
-    compression: false,
-    server: {
-      poolSize: 5,
-      auto_reconnect: true
-    },
-    ttl = 60
+    type: 'mongodb',
+    options: {
+      host: 'localhost',
+      port: '27017',
+      username: 'username',
+      password: 'password',
+      database: 'mymondodb',
+      collection: 'cacheManager',
+      compression: false,
+      server: {
+        poolSize: 5,
+        auto_reconnect: true
+      },
+      ttl: 60
+    }
   }],
 
   defaults: ['memory-store']

--- a/api/services/stores/mongodb.js
+++ b/api/services/stores/mongodb.js
@@ -9,5 +9,10 @@ const mongoStore = require('cache-manager-mongodb')
  */
 module.exports = (config) => {
   config.store = mongoStore
-  return cacheManager.caching(config)
+  return new Promise((resolve) => {
+    config.createCollectionCallback = () => {
+      return resolve(mongoCache);
+    }
+    const mongoCache = cacheManager.caching(config)
+  })
 }

--- a/api/services/stores/mongodb.js
+++ b/api/services/stores/mongodb.js
@@ -10,9 +10,9 @@ const mongoStore = require('cache-manager-mongodb')
 module.exports = (config) => {
   config.store = mongoStore
   return new Promise((resolve) => {
-    config.createCollectionCallback = () => {
-      return resolve(mongoCache);
-    }
     const mongoCache = cacheManager.caching(config)
+    config.createCollectionCallback = () => {
+      return resolve(mongoCache)
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cache-manager-fs": "^1.0.5",
     "cache-manager-fs-binary": "^1.0.2",
     "cache-manager-hazelcast": "^0.2.1",
-    "cache-manager-mongodb": "v4l3r10/node-cache-manager-mongodb",
+    "cache-manager-mongodb": "^0.1.7",
     "cache-manager-mongoose": "0.0.1",
     "cache-manager-redis": "^0.2.3",
     "lodash": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cache-manager-fs": "^1.0.5",
     "cache-manager-fs-binary": "^1.0.2",
     "cache-manager-hazelcast": "^0.2.1",
-    "cache-manager-mongodb": "^0.1.6",
+    "cache-manager-mongodb": "v4l3r10/node-cache-manager-mongodb",
     "cache-manager-mongoose": "0.0.1",
     "cache-manager-redis": "^0.2.3",
     "lodash": "^4.14.0",


### PR DESCRIPTION
Related to https://github.com/v4l3r10/node-cache-manager-mongodb/issues/2

Unfortunately, node-cache-manager-mongodb has no new release, hence the change in package.json (to be set to a new release number when a new release is created)
